### PR TITLE
Add a way to build authorization URL dynamically 

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -39,13 +39,14 @@ var passport = require('passport-strategy')
  *
  * Options:
  *
- *   - `requestTokenURL`       URL used to obtain an unauthorized request token
- *   - `accessTokenURL`        URL used to exchange a user-authorized request token for an access token
- *   - `userAuthorizationURL`  URL used to obtain user authorization
- *   - `consumerKey`           identifies client to service provider
- *   - `consumerSecret`        secret used to establish ownership of the consumer key
- *   - `callbackURL`           URL to which the service provider will redirect the user after obtaining authorization
- *   - `passReqToCallback`     when `true`, `req` is the first argument to the verify callback (default: `false`)
+ *   - `requestTokenURL`               URL used to obtain an unauthorized request token
+ *   - `accessTokenURL`                URL used to exchange a user-authorized request token for an access token
+ *   - `userAuthorizationURL`          URL used to obtain user authorization
+ *   - `userAuthorizationURLProvider`  Function that builds URL for user autorization
+ *   - `consumerKey`                   identifies client to service provider
+ *   - `consumerSecret`                secret used to establish ownership of the consumer key
+ *   - `callbackURL`                   URL to which the service provider will redirect the user after obtaining authorization
+ *   - `passReqToCallback`             when `true`, `req` is the first argument to the verify callback (default: `false`)
  *
  * Examples:
  *
@@ -75,18 +76,26 @@ function OAuthStrategy(options, verify) {
     options = undefined;
   }
   options = options || {};
-  
+
   if (!verify) { throw new TypeError('OAuthStrategy requires a verify callback'); }
   if (!options.requestTokenURL) { throw new TypeError('OAuthStrategy requires a requestTokenURL option'); }
   if (!options.accessTokenURL) { throw new TypeError('OAuthStrategy requires a accessTokenURL option'); }
-  if (!options.userAuthorizationURL) { throw new TypeError('OAuthStrategy requires a userAuthorizationURL option'); }
   if (!options.consumerKey) { throw new TypeError('OAuthStrategy requires a consumerKey option'); }
   if (options.consumerSecret === undefined) { throw new TypeError('OAuthStrategy requires a consumerSecret option'); }
-  
+
+  var provider = options.userAuthorizationURLProvider;
+  if (typeof provider !== 'function') {
+    if (!options.userAuthorizationURL) {
+      throw new TypeError('OAuthStrategy requires a userAuthorizationURL option if no userAuthorizationURLProvider is given');
+    }
+  } else {
+    this._userAuthorizationURLProvider = provider;
+  }
+
   passport.Strategy.call(this);
   this.name = 'oauth';
   this._verify = verify;
-  
+
   // NOTE: The _oauth property is considered "protected".  Subclasses are
   //       allowed to use it when making protected resource requests to retrieve
   //       the user profile.
@@ -94,7 +103,7 @@ function OAuthStrategy(options, verify) {
                           options.consumerKey,  options.consumerSecret,
                           '1.0', null, options.signatureMethod || 'HMAC-SHA1',
                           null, options.customHeaders);
-  
+
   this._userAuthorizationURL = options.userAuthorizationURL;
   this._callbackURL = options.callbackURL;
   this._key = options.sessionKey || 'oauth';
@@ -118,9 +127,9 @@ util.inherits(OAuthStrategy, passport.Strategy);
 OAuthStrategy.prototype.authenticate = function(req, options) {
   options = options || {};
   if (!req.session) { return this.error(new Error('OAuthStrategy requires session support. Did you forget app.use(express.session(...))?')); }
-  
+
   var self = this;
-  
+
   if (req.query && req.query.oauth_token) {
     // The request being authenticated contains an oauth_token parameter in the
     // query portion of the URL.  This indicates that the service provider has
@@ -134,23 +143,23 @@ OAuthStrategy.prototype.authenticate = function(req, options) {
     // This access token and token secret, along with the optional ability to
     // fetch profile information from the service provider, is sufficient to
     // establish the identity of the user.
-    
+
     // Bail if the session does not contain the request token and corresponding
     // secret.  If this happens, it is most likely caused by initiating OAuth
     // from a different host than that of the callback endpoint (for example:
     // initiating from 127.0.0.1 but handling callbacks at localhost).
     if (!req.session[self._key]) { return self.error(new Error('Failed to find request token in session')); }
-    
+
     var oauthToken = req.query.oauth_token;
     var oauthVerifier = req.query.oauth_verifier || null;
     var oauthTokenSecret = req.session[self._key].oauth_token_secret;
-    
+
     // NOTE: The oauth_verifier parameter will be supplied in the query portion
     //       of the redirect URL, if the server supports OAuth 1.0a.
-    
+
     this._oauth.getOAuthAccessToken(oauthToken, oauthTokenSecret, oauthVerifier, function(err, token, tokenSecret, params) {
       if (err) { return self.error(self._createOAuthError('Failed to obtain access token', err)); }
-      
+
       // The request token has been exchanged for an access token.  Since the
       // request token is a single-use token, that data can be removed from the
       // session.
@@ -159,16 +168,16 @@ OAuthStrategy.prototype.authenticate = function(req, options) {
       if (Object.keys(req.session[self._key]).length === 0) {
         delete req.session[self._key];
       }
-      
+
       self._loadUserProfile(token, tokenSecret, params, function(err, profile) {
         if (err) { return self.error(err); }
-        
+
         function verified(err, user, info) {
           if (err) { return self.error(err); }
           if (!user) { return self.fail(info); }
           self.success(user, info);
         }
-        
+
         try {
           if (self._passReqToCallback) {
             var arity = self._verify.length;
@@ -201,7 +210,7 @@ OAuthStrategy.prototype.authenticate = function(req, options) {
     // token secret needs to be known.  The token secret will be temporarily
     // stored in the session, so that it can be retrieved upon the user being
     // redirected back to the application.
-    
+
     var params = this.requestTokenParams(options);
     var callbackURL = options.callbackURL || this._callbackURL;
     if (callbackURL) {
@@ -213,10 +222,10 @@ OAuthStrategy.prototype.authenticate = function(req, options) {
       }
     }
     params.oauth_callback = callbackURL;
-    
+
     this._oauth.getOAuthRequestToken(params, function(err, token, tokenSecret, params) {
       if (err) { return self.error(self._createOAuthError('Failed to obtain request token', err)); }
-      
+
       // NOTE: params will contain an oauth_callback_confirmed property set to
       //       true, if the server supports OAuth 1.0a.
       //       { oauth_callback_confirmed: 'true' }
@@ -313,14 +322,14 @@ OAuthStrategy.prototype.parseErrorResponse = function(body, status) {
  */
 OAuthStrategy.prototype._loadUserProfile = function(token, tokenSecret, params, done) {
   var self = this;
-  
+
   function loadIt() {
     return self.userProfile(token, tokenSecret, params, done);
   }
   function skipIt() {
     return done(null);
   }
-  
+
   if (typeof this._skipUserProfile == 'function' && this._skipUserProfile.length > 1) {
     // async
     this._skipUserProfile(token, tokenSecret, function(err, skip) {

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -55,7 +55,25 @@ var passport = require('passport-strategy')
  *         accessTokenURL: 'https://www.example.com/oauth/access_token',
  *         userAuthorizationURL: 'https://www.example.com/oauth/authorize',
  *         consumerKey: '123-456-789',
- *         consumerSecret: 'shhh-its-a-secret'
+ *         consumerSecret: 'shhh-its-a-secret',
+ *         callbackURL: 'https://www.example.net/auth/example/callback'
+ *       },
+ *       function(token, tokenSecret, profile, done) {
+ *         User.findOrCreate(..., function (err, user) {
+ *           done(err, user);
+ *         });
+ *       }
+ *     ));
+ *
+ *
+ *     passport.use(new OAuthStrategy({
+ *         requestTokenURL: 'https://www.example.com/oauth/request_token',
+ *         accessTokenURL: 'https://www.example.com/oauth/access_token',
+ *         userAuthorizationURLProvider: function (token, tokenSecret, params, req, options) {
+ *           return params['url_advertised_by_service_in_reply_parameter'];
+ *         },
+ *         consumerKey: '123-456-789',
+ *         consumerSecret: 'shhh-its-a-secret',
  *         callbackURL: 'https://www.example.net/auth/example/callback'
  *       },
  *       function(token, tokenSecret, profile, done) {
@@ -234,12 +252,7 @@ OAuthStrategy.prototype.authenticate = function(req, options) {
       req.session[self._key].oauth_token = token;
       req.session[self._key].oauth_token_secret = tokenSecret;
 
-      var parsed = url.parse(self._userAuthorizationURL, true);
-      parsed.query.oauth_token = token;
-      utils.merge(parsed.query, self.userAuthorizationParams(options));
-      delete parsed.search;
-      var location = url.format(parsed);
-      self.redirect(location);
+      self.redirect(self._userAuthorizationURLProvider(token, tokenSecret, params, req, options));
     });
   }
 };
@@ -342,6 +355,26 @@ OAuthStrategy.prototype._loadUserProfile = function(token, tokenSecret, params, 
     if (!skip) { return loadIt(); }
     return skipIt();
   }
+};
+
+/**
+ * Return URL for user to be redirect to for authorization. Default impelentation uses userAuthorizationURL
+ *
+ * @param {Object} req
+ * @param {Object} options
+ * @param {String} token
+ * @param {String} tokenSecret
+ * @param {Object} params
+ * @api private
+ */
+OAuthStrategy.prototype._userAuthorizationURLProvider = function (token, tokenSecret, params, req, options) {
+  var self = this;
+
+  var parsed = url.parse(self._userAuthorizationURL, true);
+  parsed.query.oauth_token = token;
+  utils.merge(parsed.query, self.userAuthorizationParams(options));
+  delete parsed.search;
+  return url.format(parsed);
 };
 
 /**

--- a/test/oauth.custom.authorize.url.test.js
+++ b/test/oauth.custom.authorize.url.test.js
@@ -1,0 +1,64 @@
+var chai = require('chai')
+  , OAuthStrategy = require('../lib/strategy');
+
+
+describe('OAuthStrategy', function() {
+
+  describe('that is given no userAuthorizationURLProvider', function() {
+    it('should require userAuthorizationURL option', function() {
+      var strategyConstructor = OAuthStrategy.bind(
+        function () {},
+        {
+          requestTokenURL: 'https://www.example.com/oauth/request_token',
+          accessTokenURL: 'https://www.example.com/oauth/access_token',
+          consumerKey: 'ABC123',
+          consumerSecret: 'secret'
+        },
+        function() {}
+      );
+
+      expect(strategyConstructor).to.throw(TypeError,
+        'OAuthStrategy requires a userAuthorizationURL option if no userAuthorizationURLProvider is given');
+    });
+  });
+
+  describe('that is given a userAuthorizationURLProvider', function() {
+    it('should not require userAuthorizationURL option', function() {
+      var strategyConstructor = OAuthStrategy.bind(
+        function () {},
+        {
+          requestTokenURL: 'https://www.example.com/oauth/request_token',
+          accessTokenURL: 'https://www.example.com/oauth/access_token',
+          consumerKey: 'ABC123',
+          consumerSecret: 'secret',
+          userAuthorizationURLProvider: function(req, res) {
+          }
+        },
+        function() {}
+      );
+
+      expect(strategyConstructor).to.not.throw(TypeError);
+    });
+  });
+
+  describe('that is given both userAuthorizationURL and userAuthorizationURLProvider', function() {
+    it('should be constructed wihtout issues', function() {
+      var strategyConstructor = OAuthStrategy.bind(
+        function () {},
+        {
+          requestTokenURL: 'https://www.example.com/oauth/request_token',
+          accessTokenURL: 'https://www.example.com/oauth/access_token',
+          userAuthorizationURL: 'https://www.example.com/oauth/authorize',
+          consumerKey: 'ABC123',
+          consumerSecret: 'secret',
+          userAuthorizationURLProvider: function(req, res) {
+          }
+        },
+        function() {}
+      );
+
+      expect(strategyConstructor).to.not.throw(TypeError);
+    });
+  });
+
+});


### PR DESCRIPTION
[OAuth1](https://tools.ietf.org/html/rfc5849) requires [three endpoints](https://tools.ietf.org/html/rfc5849#page-9) to work. However it does not specify how server should advertise URLs of these endpoints:

> The methods in which the server advertises and documents its three endpoints are beyond the scope of this specification.  Clients should avoid making assumptions about the size of tokens and other server-generated values, which are left undefined by this specification.

Working with [Etsy](etsy.com) we need to be able to use a parameter [`login_url` returned by `Temporary Credential Request` ](https://www.etsy.com/developers/documentation/getting_started/oauth#section_obtaining_temporary_credentials). This means we cannot use static `userAuthorizationURL`.

This pull request adds optional `userAuthorizationURLProvider` that is a function called with results of `Temporary Credential Request`. Default logic stays the same (i.e. `userAuthorizationURL` is used). If `userAuthorizationURLProvider` is present `userAuthorizationURL` becomes optional, but both can be used together.
